### PR TITLE
feat(search): ontology-aware tag & bundle filtering (GH#14)

### DIFF
--- a/src/http/handlers/search.rs
+++ b/src/http/handlers/search.rs
@@ -160,7 +160,11 @@ pub(super) async fn search(
     if let Some(ref tags) = params.tag {
         let tag_list: Vec<String> = tags.split(',').map(|t| t.trim().to_string()).filter(|t| !t.is_empty()).collect();
         if !tag_list.is_empty() {
-            extra_filters.push(build_tag_include_filter(&tag_list));
+            // Expand requested tags through the ontology hierarchy so a query for
+            // a parent concept (e.g. `security`) also matches descendant tags
+            // (`auth`, `session`). No-op when no ontology is configured (GH#14).
+            let expanded = state.tags_config.expand_tags_via_ontology(&tag_list);
+            extra_filters.push(build_tag_include_filter(&expanded));
         }
     }
     if let Some(ref tags) = params.exclude_tag {
@@ -169,9 +173,11 @@ pub(super) async fn search(
             extra_filters.push(build_tag_exclude_filter(&tag_list));
         }
     }
-    // Apply bundle filter (scope search to bundle member files)
+    // Apply bundle filter (scope search to bundle member files). Use the
+    // ontology-aware variant so a bundle's tags expand through the hierarchy
+    // (GH#14); falls back to plain tag membership when no ontology is defined.
     if let Some(ref bundle_name) = params.bundle {
-        if let Some(bundle_filter) = state.tags_config.build_bundle_file_filter(bundle_name) {
+        if let Some(bundle_filter) = state.tags_config.build_bundle_file_filter_with_ontology(bundle_name) {
             extra_filters.push(bundle_filter);
         }
     }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1914,4 +1914,62 @@ tags = ["docs"]
         // External role: scoped override → not pinned
         assert_eq!(config.resolve_pin("user:guardrails", Some("external/user1")), None);
     }
+
+    // ===== Ontology-aware query tests (GH#14) =====
+
+    fn ontology_config() -> TagsConfig {
+        let toml_str = r#"
+[ontology.tags.security]
+description = "Security-related code"
+
+[ontology.tags.auth]
+parent = "security"
+relates_to = ["session", "token"]
+
+[ontology.tags.session]
+parent = "auth"
+
+[[bundles]]
+name = "domain/security"
+description = "Security subsystem"
+tags = ["security"]
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn test_expand_tags_via_ontology_includes_descendants() {
+        let config = ontology_config();
+        let expanded = config.expand_tags_via_ontology(&["security".to_string()]);
+        // security → auth → session (transitive descendants)
+        assert!(expanded.contains(&"security".to_string()));
+        assert!(expanded.contains(&"auth".to_string()));
+        assert!(expanded.contains(&"session".to_string()));
+    }
+
+    #[test]
+    fn test_expand_tags_via_ontology_leaf_unchanged() {
+        let config = ontology_config();
+        let expanded = config.expand_tags_via_ontology(&["session".to_string()]);
+        // session is a leaf — only itself
+        assert_eq!(expanded, vec!["session".to_string()]);
+    }
+
+    #[test]
+    fn test_expand_tags_via_ontology_noop_without_ontology() {
+        let config = TagsConfig::default();
+        let input = vec!["security".to_string(), "auth".to_string()];
+        assert_eq!(config.expand_tags_via_ontology(&input), input);
+    }
+
+    #[test]
+    fn test_build_bundle_file_filter_with_ontology_expands_tags() {
+        let config = ontology_config();
+        let filter = config
+            .build_bundle_file_filter_with_ontology("domain/security")
+            .expect("bundle filter");
+        // The bundle's `security` tag should expand to include descendants.
+        assert!(filter.contains("auth"), "filter was: {filter}");
+        assert!(filter.contains("session"), "filter was: {filter}");
+    }
 }


### PR DESCRIPTION
## Summary

Advances #14. Bobbin already has the ontology building blocks — and a prior changeset (per the issue's gap analysis) already landed:
- **Direction 1 (tag hierarchy)** — `parent`/`relates_to` in `[ontology.tags]`, plus `bobbin ontology show/expand/path/list/tree`
- **Direction 2 (bundle ontology)** — `implements`/`depends_on`/`tests` typed bundle edges
- **Direction 3 (chunk relationships)** — `ChunkEdge`/`ChunkEdgeType` extracted by tree-sitter

The remaining gap was **Direction 4 (ontology-aware query)**: the helpers existed (`expand_tags_via_ontology`, `build_bundle_file_filter_with_ontology`) but the **search handler never called them**. So `tag=security` did not pull in `auth`/`session` even when defined as descendants.

## Change

Wire ontology expansion into the HTTP search handler (`src/http/handlers/search.rs`):
- `tag=` filters expand through the hierarchy before the include filter is built
- bundle filters use the ontology-aware variant (expands the bundle's tags)

Both are **no-ops when no `[ontology.tags]` is configured**, so existing deployments behave identically.

## Tests

Added unit tests in `src/tags.rs`: transitive expansion, leaf tag unchanged, no-op without ontology, and ontology-aware bundle filter expansion. All pass.

## Follow-ups
- CLI local search (`src/cli/search.rs`) doesn't load a `TagsConfig`; not wired here. The HTTP path serves all agents (thin-client → search.svc).
- REST endpoints for ontology navigation (`/ontology/tags`, `/ontology/path`) remain CLI-only — candidate for a future PR.
- Direction 5 (auto-discovery) still open; feeds from #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)