### PR TITLE
feat(telemetry): bead→commit lineage logging — GH#9 Layer 1

### DIFF
--- a/src/cli/bead.rs
+++ b/src/cli/bead.rs
@@ -1,0 +1,214 @@
+use anyhow::{anyhow, Context, Result};
+use clap::{Args, Subcommand};
+use colored::Colorize;
+use serde::Serialize;
+use std::path::Path;
+use std::process::Command;
+
+use super::OutputConfig;
+use crate::config::Config;
+use crate::storage::sqlite::{BeadLineageRecord, MetadataStore, NewBeadLineage};
+
+#[derive(Args)]
+pub struct BeadArgs {
+    #[command(subcommand)]
+    command: BeadCommand,
+}
+
+#[derive(Subcommand)]
+enum BeadCommand {
+    /// Link a bead to a commit and its changeset (workflow telemetry, GH#9)
+    Link {
+        /// Bead identifier (e.g. bo-abc123)
+        bead_id: String,
+
+        /// Commit SHA the bead was resolved in. When given and `--files` is
+        /// omitted, the changeset is read from git automatically.
+        commit: Option<String>,
+
+        /// Explicit touched files (comma-separated). Overrides git detection.
+        #[arg(long)]
+        files: Option<String>,
+
+        /// Bead type (task | bug | feature | chore)
+        #[arg(long, name = "type")]
+        bead_type: Option<String>,
+
+        /// Associated bundle slugs (comma-separated)
+        #[arg(long)]
+        bundles: Option<String>,
+
+        /// Action type (linked | referenced | completed)
+        #[arg(long, default_value = "linked")]
+        action: String,
+    },
+
+    /// Show recorded lineage for a bead (or recent lineage across all beads)
+    History {
+        /// Bead identifier to filter by (omit for recent lineage across beads)
+        bead_id: Option<String>,
+
+        /// Filter by commit SHA
+        #[arg(long)]
+        commit: Option<String>,
+
+        /// Maximum number of records
+        #[arg(long, short = 'n', default_value = "20")]
+        limit: usize,
+    },
+}
+
+#[derive(Serialize)]
+struct LinkOutput {
+    id: i64,
+    bead_id: String,
+    commit_sha: Option<String>,
+    touched_files: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct HistoryEntry {
+    id: i64,
+    created_at: String,
+    bead_id: String,
+    bead_type: Option<String>,
+    commit_sha: Option<String>,
+    bundle_slugs: Option<String>,
+    touched_files: Vec<String>,
+    action_type: Option<String>,
+}
+
+impl From<BeadLineageRecord> for HistoryEntry {
+    fn from(r: BeadLineageRecord) -> Self {
+        HistoryEntry {
+            id: r.id,
+            created_at: r.created_at,
+            bead_id: r.bead_id,
+            bead_type: r.bead_type,
+            commit_sha: r.commit_sha,
+            bundle_slugs: r.bundle_slugs,
+            touched_files: r.touched_files,
+            action_type: r.action_type,
+        }
+    }
+}
+
+pub async fn run(args: BeadArgs, output: OutputConfig) -> Result<()> {
+    let repo_root = super::find_bobbin_root()
+        .ok_or_else(|| anyhow!("Not inside a bobbin repository (run `bobbin init` first)"))?;
+    let store = MetadataStore::open(&Config::db_path(&repo_root))
+        .context("Failed to open metadata store")?;
+
+    match args.command {
+        BeadCommand::Link {
+            bead_id,
+            commit,
+            files,
+            bead_type,
+            bundles,
+            action,
+        } => {
+            // Resolve touched files: explicit --files wins, else derive from commit.
+            let touched_files: Vec<String> = if let Some(f) = files {
+                f.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            } else if let Some(ref sha) = commit {
+                files_in_commit(&repo_root, sha).unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+
+            let id = store.record_bead_lineage(&NewBeadLineage {
+                bead_id: bead_id.clone(),
+                bead_type,
+                commit_sha: commit.clone(),
+                bundle_slugs: bundles,
+                touched_files: touched_files.clone(),
+                action_type: Some(action),
+            })?;
+
+            if output.json {
+                let out = LinkOutput {
+                    id,
+                    bead_id,
+                    commit_sha: commit,
+                    touched_files,
+                };
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            } else if !output.quiet {
+                println!(
+                    "{} Linked {} {} ({} file{})",
+                    "✓".green(),
+                    bead_id.cyan(),
+                    commit
+                        .as_deref()
+                        .map(|c| format!("→ {}", &c[..c.len().min(8)]))
+                        .unwrap_or_default(),
+                    touched_files.len(),
+                    if touched_files.len() == 1 { "" } else { "s" },
+                );
+            }
+        }
+
+        BeadCommand::History {
+            bead_id,
+            commit,
+            limit,
+        } => {
+            let records =
+                store.list_bead_lineage(bead_id.as_deref(), commit.as_deref(), limit)?;
+
+            if output.json {
+                let entries: Vec<HistoryEntry> =
+                    records.into_iter().map(HistoryEntry::from).collect();
+                println!("{}", serde_json::to_string_pretty(&entries)?);
+            } else if !output.quiet {
+                if records.is_empty() {
+                    println!("{}", "No bead lineage recorded yet.".dimmed());
+                } else {
+                    for r in &records {
+                        let sha = r
+                            .commit_sha
+                            .as_deref()
+                            .map(|c| &c[..c.len().min(8)])
+                            .unwrap_or("-");
+                        println!(
+                            "{}  {}  {}  {} file(s)  {}",
+                            r.created_at.dimmed(),
+                            r.bead_id.cyan(),
+                            sha.yellow(),
+                            r.touched_files.len(),
+                            r.action_type.as_deref().unwrap_or("").dimmed(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Return the list of files changed in a commit using git, repo-relative.
+fn files_in_commit(repo_root: &Path, sha: &str) -> Result<Vec<String>> {
+    let out = Command::new("git")
+        .current_dir(repo_root)
+        .args(["show", "--name-only", "--pretty=format:", sha])
+        .output()
+        .context("Failed to run git")?;
+    if !out.status.success() {
+        return Err(anyhow!(
+            "git show failed for {}: {}",
+            sha,
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    let files = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+    Ok(files)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+mod bead;
 mod benchmark;
 mod bundle;
 mod calibrate;
@@ -91,6 +92,9 @@ enum Commands {
     /// Submit, list, and manage feedback on bobbin context injections
     Feedback(feedback::FeedbackArgs),
 
+    /// Record and inspect bead→commit workflow lineage (telemetry)
+    Bead(bead::BeadArgs),
+
     /// Keyword/regex search
     Grep(grep::GrepArgs),
 
@@ -173,6 +177,7 @@ impl Commands {
             Commands::Context(_) => "context",
             Commands::Deps(_) => "deps",
             Commands::Feedback(_) => "feedback",
+            Commands::Bead(_) => "bead",
             Commands::Grep(_) => "grep",
             Commands::Refs(_) => "refs",
             Commands::Related(_) => "related",
@@ -287,6 +292,7 @@ async fn dispatch_command(command: Commands, output: OutputConfig) -> Result<()>
         Commands::Context(args) => context::run(args, output).await,
         Commands::Deps(args) => deps::run(args, output).await,
         Commands::Feedback(args) => feedback::run(args, output).await,
+        Commands::Bead(args) => bead::run(args, output).await,
         Commands::Grep(args) => grep::run(args, output).await,
         Commands::Refs(args) => refs::run(args, output).await,
         Commands::Related(args) => related::run(args, output).await,

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -53,8 +53,24 @@ impl MetadataStore {
                 hash TEXT NOT NULL
             );
 
+            -- Bead → bundle → commit workflow telemetry (GH#9, Layer 1: logging).
+            -- Each row records that a bead was linked to a commit / changeset, so
+            -- later layers can mine which files matter for which kinds of work.
+            CREATE TABLE IF NOT EXISTS bead_lineage (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+                bead_id TEXT NOT NULL,
+                bead_type TEXT,
+                commit_sha TEXT,
+                bundle_slugs TEXT,
+                touched_files TEXT,
+                action_type TEXT
+            );
+
             -- Indexes
             CREATE INDEX IF NOT EXISTS idx_coupling_score ON coupling(score DESC);
+            CREATE INDEX IF NOT EXISTS idx_bead_lineage_bead ON bead_lineage(bead_id);
+            CREATE INDEX IF NOT EXISTS idx_bead_lineage_commit ON bead_lineage(commit_sha);
         "#,
         )?;
 
@@ -246,6 +262,106 @@ impl MetadataStore {
         self.conn.execute("DELETE FROM file_hashes", [])?;
         Ok(())
     }
+
+    /// Record a bead→commit lineage entry (GH#9 Layer 1 logging).
+    ///
+    /// Returns the row id of the inserted record. `touched_files` is stored as
+    /// a JSON array so later layers can aggregate over changesets.
+    pub fn record_bead_lineage(&self, rec: &NewBeadLineage) -> Result<i64> {
+        let touched_files_json = serde_json::to_string(&rec.touched_files)
+            .unwrap_or_else(|_| "[]".to_string());
+        self.conn.execute(
+            r#"INSERT INTO bead_lineage
+                   (bead_id, bead_type, commit_sha, bundle_slugs, touched_files, action_type)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6)"#,
+            rusqlite::params![
+                rec.bead_id,
+                rec.bead_type,
+                rec.commit_sha,
+                rec.bundle_slugs,
+                touched_files_json,
+                rec.action_type,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// List bead lineage records, optionally filtered by bead id and/or commit.
+    /// Most recent first.
+    pub fn list_bead_lineage(
+        &self,
+        bead_id: Option<&str>,
+        commit_sha: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<BeadLineageRecord>> {
+        let mut sql = String::from(
+            "SELECT id, created_at, bead_id, bead_type, commit_sha, bundle_slugs, touched_files, action_type
+             FROM bead_lineage",
+        );
+        let mut conditions: Vec<String> = Vec::new();
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(b) = bead_id {
+            conditions.push(format!("bead_id = ?{}", params.len() + 1));
+            params.push(Box::new(b.to_string()));
+        }
+        if let Some(c) = commit_sha {
+            conditions.push(format!("commit_sha = ?{}", params.len() + 1));
+            params.push(Box::new(c.to_string()));
+        }
+        if !conditions.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&conditions.join(" AND "));
+        }
+        sql.push_str(&format!(" ORDER BY id DESC LIMIT ?{}", params.len() + 1));
+        params.push(Box::new(limit as i64));
+
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                let touched_json: Option<String> = row.get(6)?;
+                let touched_files = touched_json
+                    .and_then(|j| serde_json::from_str::<Vec<String>>(&j).ok())
+                    .unwrap_or_default();
+                Ok(BeadLineageRecord {
+                    id: row.get(0)?,
+                    created_at: row.get(1)?,
+                    bead_id: row.get(2)?,
+                    bead_type: row.get(3)?,
+                    commit_sha: row.get(4)?,
+                    bundle_slugs: row.get(5)?,
+                    touched_files,
+                    action_type: row.get(7)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+}
+
+/// Input for recording a bead lineage entry. `id`/`created_at` are assigned by
+/// the database.
+#[derive(Debug, Clone, Default)]
+pub struct NewBeadLineage {
+    pub bead_id: String,
+    pub bead_type: Option<String>,
+    pub commit_sha: Option<String>,
+    pub bundle_slugs: Option<String>,
+    pub touched_files: Vec<String>,
+    pub action_type: Option<String>,
+}
+
+/// A stored bead→commit lineage record.
+#[derive(Debug, Clone)]
+pub struct BeadLineageRecord {
+    pub id: i64,
+    pub created_at: String,
+    pub bead_id: String,
+    pub bead_type: Option<String>,
+    pub commit_sha: Option<String>,
+    pub bundle_slugs: Option<String>,
+    pub touched_files: Vec<String>,
+    pub action_type: Option<String>,
 }
 
 #[cfg(test)]
@@ -434,6 +550,56 @@ mod tests {
 
         assert!(store.get_file_hash("src/a.rs").unwrap().is_none());
         assert!(store.get_file_hash("src/b.rs").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_bead_lineage_record_and_list() {
+        let (store, _dir) = create_test_store();
+
+        store
+            .record_bead_lineage(&NewBeadLineage {
+                bead_id: "bo-abc".to_string(),
+                bead_type: Some("bug".to_string()),
+                commit_sha: Some("deadbeef".to_string()),
+                bundle_slugs: Some("search-reranking".to_string()),
+                touched_files: vec!["src/search/weights.rs".to_string(), "src/a.rs".to_string()],
+                action_type: Some("linked".to_string()),
+            })
+            .unwrap();
+
+        let all = store.list_bead_lineage(None, None, 10).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].bead_id, "bo-abc");
+        assert_eq!(all[0].commit_sha.as_deref(), Some("deadbeef"));
+        assert_eq!(all[0].touched_files.len(), 2);
+        assert!(all[0].touched_files.contains(&"src/a.rs".to_string()));
+
+        // Filter by bead id
+        let by_bead = store.list_bead_lineage(Some("bo-abc"), None, 10).unwrap();
+        assert_eq!(by_bead.len(), 1);
+        assert!(store.list_bead_lineage(Some("bo-zzz"), None, 10).unwrap().is_empty());
+
+        // Filter by commit
+        let by_commit = store.list_bead_lineage(None, Some("deadbeef"), 10).unwrap();
+        assert_eq!(by_commit.len(), 1);
+    }
+
+    #[test]
+    fn test_bead_lineage_ordering_and_limit() {
+        let (store, _dir) = create_test_store();
+        for i in 0..5 {
+            store
+                .record_bead_lineage(&NewBeadLineage {
+                    bead_id: format!("bo-{i}"),
+                    commit_sha: Some(format!("sha{i}")),
+                    ..Default::default()
+                })
+                .unwrap();
+        }
+        let recent = store.list_bead_lineage(None, None, 3).unwrap();
+        assert_eq!(recent.len(), 3);
+        // Most recent (highest id) first
+        assert_eq!(recent[0].bead_id, "bo-4");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **Layer 1 (logging)** of the Bead→Bundle→Commit learning loop (#9). This is the foundation every later layer builds on: a durable record of which beads were resolved in which commits/changesets.

## What's included

**Storage** (`src/storage/sqlite.rs`)
- New `bead_lineage` table: `bead_id`, `bead_type`, `commit_sha`, `bundle_slugs`, `touched_files` (JSON), `action_type`, `created_at`; indexed on `bead_id` and `commit_sha`.
- `record_bead_lineage()` / `list_bead_lineage(bead_id?, commit?, limit)`.

**CLI** (`src/cli/bead.rs`)
- `bobbin bead link <bead-id> [<commit>] [--files a,b] [--bead-type bug] [--bundles slug] [--action linked]` — when a commit is given and `--files` is omitted, the changeset is read from git (`git show --name-only`).
- `bobbin bead history [<bead-id>] [--commit <sha>] [-n 20]` — text + `--json`.

## Scope

Deliberately Layer 1 only. Layers 2–5 from the issue (frequency-based bundle suggestions, association mining, predictive priming, graph enrichment) all read from this table.

**Follow-ups:**
- Auto-association via post-commit hook (commit message contains bead ID → auto `link`).
- MCP `bead_link` / `bead_history` tools (mirror the existing `feedback_lineage_*` tools).

## Tests
- Unit: record/list, filter-by-bead, filter-by-commit, ordering + limit.
- End-to-end: `bead link` (explicit files + git-derived) and `bead history` (text + JSON) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)