### PR TITLE
fix: clear bobbin bug backlog (bo-f61, bo-92t, bo-ewk, bo-b0nn, bo-ruuc)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,10 +91,15 @@ jobs:
         run: |
           ORT_TAG="v${{ matrix.ort_version }}"
           ORT_TARBALL="${{ matrix.ort_asset }}-${{ matrix.ort_version }}.tgz"
-          curl -sL "https://github.com/microsoft/onnxruntime/releases/download/${ORT_TAG}/${ORT_TARBALL}" \
+          # --fail so a missing/renamed asset errors here, not 2 steps later.
+          curl -sSL --fail "https://github.com/microsoft/onnxruntime/releases/download/${ORT_TAG}/${ORT_TARBALL}" \
             -o /tmp/ort.tgz
           mkdir -p /tmp/ort-extracted
-          tar xzf /tmp/ort.tgz -C /tmp/ort-extracted --strip-components=1
+          # NOTE: do NOT use --strip-components here. The osx-x86_64 tarball entries
+          # carry a leading "./" component (others don't), so strip-components=1 would
+          # remove "." and leave the lib one level too deep. Extract verbatim and let
+          # the Package step locate lib/ wherever it lands. See bo-ewk.
+          tar xzf /tmp/ort.tgz -C /tmp/ort-extracted
 
       - name: Package
         shell: bash
@@ -103,11 +108,26 @@ jobs:
           mkdir -p "$STAGING/lib"
           cp target/${{ matrix.target }}/release/bobbin "$STAGING/"
 
-          # Bundle ONNX Runtime shared library from extracted tarball
-          find /tmp/ort-extracted/lib -maxdepth 1 -name "libonnxruntime*" \
-            -not -name "*providers*" -not -type d | while read f; do
+          # Bundle ONNX Runtime shared library from extracted tarball.
+          # Locate the lib/ dir regardless of how deep the tarball nests it
+          # (osx-x86_64 nests one level deeper — see bo-ewk).
+          ORT_LIB_DIR=$(find /tmp/ort-extracted -type d -name lib | head -1)
+          if [ -z "$ORT_LIB_DIR" ]; then
+            echo "ERROR: no lib/ dir found under /tmp/ort-extracted" >&2
+            find /tmp/ort-extracted -maxdepth 2 >&2
+            exit 1
+          fi
+          copied=0
+          for f in $(find "$ORT_LIB_DIR" -maxdepth 1 -name "libonnxruntime*" \
+            -not -name "*providers*" -not -name "*.pc" -not -type d); do
             cp "$f" "$STAGING/lib/"
+            copied=$((copied + 1))
           done
+          if [ "$copied" -eq 0 ]; then
+            echo "ERROR: no libonnxruntime* libraries copied from $ORT_LIB_DIR" >&2
+            ls -la "$ORT_LIB_DIR" >&2
+            exit 1
+          fi
 
           tar czvf "${STAGING}.tar.gz" "$STAGING"
 

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -205,7 +205,7 @@ pub async fn run(args: ContextArgs, output: OutputConfig) -> Result<()> {
         role: None,
         file_type_rules: vec![],
             repo_affinity: None,
-            repo_affinity_boost: 2.0,
+            repo_affinity_boost: config.hooks.repo_affinity_boost,
             max_bridged_files: 3,
             max_bridged_chunks_per_file: 2,
             repo_path_prefix: config.server.repo_path_prefix.clone(),

--- a/src/cli/index.rs
+++ b/src/cli/index.rs
@@ -301,7 +301,16 @@ pub async fn run(args: IndexArgs, output: OutputConfig) -> Result<()> {
 
     let total_files = files_needing_index.len();
 
-    if total_files == 0 {
+    // Beads/commits indexing can run even with 0 changed source files (a dedicated
+    // `--include-beads` pass, or a no-change incremental). Compute those flags up
+    // front so the up-to-date fast path only fires when there is genuinely nothing
+    // else to do; otherwise fall through (the file-embedding loops below are no-ops
+    // at 0 files) so beads/commits still index. See bo-f61.
+    let commits_enabled = config.git.commits_enabled;
+    let include_beads =
+        (args.include_beads || config.beads.enabled) && !config.beads.databases.is_empty();
+
+    if total_files == 0 && !commits_enabled && !include_beads {
         if output.json {
             let json_output = IndexOutput {
                 status: "up_to_date".to_string(),
@@ -739,7 +748,7 @@ pub async fn run(args: IndexArgs, output: OutputConfig) -> Result<()> {
     // Index git commits as searchable chunks
     let t_commits = Instant::now();
     let mut commits_indexed: usize = 0;
-    if config.git.commits_enabled {
+    if commits_enabled {
         if output.verbose && !output.quiet && !output.json {
             println!("  Indexing git commits...");
         }
@@ -913,8 +922,7 @@ pub async fn run(args: IndexArgs, output: OutputConfig) -> Result<()> {
 
     // Index beads from Dolt if enabled
     let mut beads_indexed: usize = 0;
-    let include_beads = args.include_beads || config.beads.enabled;
-    if include_beads && !config.beads.databases.is_empty() {
+    if include_beads {
         if !output.quiet && !output.json {
             println!("  Indexing beads from Dolt...");
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,7 +274,9 @@ pub struct SearchConfig {
     pub rrf_k: f32,
     /// Demotion factor for Documentation/Config files in search ranking.
     /// Applied as a multiplier to RRF scores: 1.0 = no demotion, 0.0 = full demotion.
-    /// Source/Test files are unaffected. Default: 0.5 (halve doc/config scores).
+    /// Source/Test files are unaffected. Default: 0.3 (demote doc/config to 30%).
+    /// This is the single source of truth — `ContextConfig::doc_demotion` defaults
+    /// to the same value and every assembly path overrides it from here.
     pub doc_demotion: f32,
     /// Personalized PageRank ranking weight (0.0 = disabled). Requires the
     /// `knowledge` feature + a populated Quipu coupling graph. Bounded boost:
@@ -1113,6 +1115,24 @@ coupling_depth = 500
         assert!((config.search.doc_demotion - 0.3).abs() < f32::EPSILON);
     }
 
+    // bo-b0nn: doc_demotion has one source of truth. SearchConfig is canonical;
+    // ContextConfig::default() must match it so the two never drift (a stale 0.5
+    // comment + a 0.5 ContextConfig default previously disagreed with the 0.3
+    // effective default).
+    #[test]
+    fn test_doc_demotion_single_source_of_truth() {
+        let search_default = SearchConfig::default().doc_demotion;
+        let context_default = crate::search::context::ContextConfig::default().doc_demotion;
+        assert!(
+            (search_default - 0.3).abs() < f32::EPSILON,
+            "SearchConfig::doc_demotion default should be 0.3, got {search_default}"
+        );
+        assert!(
+            (search_default - context_default).abs() < f32::EPSILON,
+            "ContextConfig default ({context_default}) must match SearchConfig ({search_default})"
+        );
+    }
+
     #[test]
     fn test_search_config_custom() {
         let toml_str = r#"
@@ -1151,6 +1171,20 @@ semantic_weight = 0.8
         assert_eq!(config.hooks.min_prompt_length, 20);
         assert!((config.hooks.gate_threshold - 0.45).abs() < f32::EPSILON);
         assert!(config.hooks.dedup_enabled);
+        assert!((config.hooks.repo_affinity_boost - 2.0).abs() < f32::EPSILON);
+    }
+
+    // bo-ruuc: repo_affinity_boost must be configurable and parsed from [hooks];
+    // `bobbin context` now sources it from config.hooks.repo_affinity_boost rather
+    // than a hardcoded 2.0.
+    #[test]
+    fn test_hooks_repo_affinity_boost_custom() {
+        let toml_str = r#"
+[hooks]
+repo_affinity_boost = 3.5
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!((config.hooks.repo_affinity_boost - 3.5).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -120,7 +120,10 @@ impl BobbinMcpServer {
             "commit" => Ok(ChunkType::Commit),
             "issue" | "bead" => Ok(ChunkType::Issue),
             "other" => Ok(ChunkType::Other),
-            _ => anyhow::bail!("Unknown chunk type '{}'", s),
+            _ => anyhow::bail!(
+                "Unknown chunk type '{}'. Valid types: function, method, class, struct, enum, interface, module, impl, trait, doc, section, table, code_block, commit, issue, other",
+                s
+            ),
         }
     }
 

--- a/src/search/context.rs
+++ b/src/search/context.rs
@@ -62,8 +62,9 @@ pub struct ContextConfig {
     pub content_mode: ContentMode,
     pub search_limit: usize,
     /// Demotion factor for Documentation/Config files in search ranking.
-    /// Applied as a multiplier to RRF scores: 1.0 = no demotion, 0.5 = half score.
-    /// Source/Test files are unaffected. Default: 0.5.
+    /// Applied as a multiplier to RRF scores: 1.0 = no demotion, 0.3 = 30% score.
+    /// Source/Test files are unaffected. Default: 0.3 — kept in sync with
+    /// `SearchConfig::doc_demotion`, the single source of truth.
     pub doc_demotion: f32,
     /// Half-life for recency decay in days (0.0 = disabled)
     pub recency_half_life_days: f32,
@@ -132,7 +133,7 @@ impl Default for ContextConfig {
             semantic_weight: 0.7,
             content_mode: ContentMode::Full,
             search_limit: 20,
-            doc_demotion: 0.5,
+            doc_demotion: 0.3,
             recency_half_life_days: 0.0,
             recency_weight: 0.0,
             rrf_k: 60.0,

--- a/tests/cli_index.rs
+++ b/tests/cli_index.rs
@@ -94,6 +94,52 @@ fn index_incremental_skips_unchanged_files() {
     assert_eq!(json["files_indexed"], 0, "no files should be re-indexed");
 }
 
+/// bo-f61: a no-change re-index with commits enabled must still fall through and
+/// index git commits, instead of taking the `total_files == 0` up-to-date fast
+/// path (which previously skipped the commits + beads blocks entirely). The beads
+/// block shares the exact same early-return gate, so this exercises that gate
+/// without requiring Dolt infrastructure.
+#[test]
+fn index_zero_files_still_indexes_commits() {
+    let project = TestProject::new();
+    project.write_rust_fixtures();
+    project.git_commit("initial");
+    project.bobbin_init();
+
+    // First index establishes file hashes (skip if ONNX runtime unavailable).
+    if !project.bobbin_index() { return };
+
+    // Enable commit indexing in the project config (generated config disables it).
+    let config_path = project.path().join(".bobbin/config.toml");
+    let cfg = std::fs::read_to_string(&config_path).unwrap();
+    assert!(cfg.contains("commits_enabled = false"), "expected commits disabled in generated config");
+    let cfg = cfg.replace("commits_enabled = false", "commits_enabled = true");
+    std::fs::write(&config_path, cfg).unwrap();
+
+    // Re-index with NO changed source files. Pre-fix this returned "up_to_date"
+    // and skipped commits; now it must fall through to the commits block.
+    let output = TestProject::bobbin_cmd()
+        .args(["--json", "index"])
+        .arg(project.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(
+        json["status"], "indexed",
+        "0-file index with commits enabled must fall through, not fast-return up_to_date"
+    );
+    assert_eq!(json["files_indexed"], 0, "no source files changed");
+    assert!(
+        json["commits_indexed"].as_u64().unwrap_or(0) >= 1,
+        "commits should be indexed on the 0-file pass, got {:?}",
+        json["commits_indexed"]
+    );
+}
+
 #[test]
 fn index_incremental_reindexes_modified_file() {
     let project = TestProject::new();

--- a/tests/cli_search.rs
+++ b/tests/cli_search.rs
@@ -179,3 +179,51 @@ fn search_empty_index_returns_empty_index_message() {
     let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
     assert_eq!(json["error"], "empty_index");
 }
+
+// ─── --type validation (bo-92t) ─────────────────────────────────────────────
+
+/// bo-92t: an invalid `--type` value must error (non-zero exit) and name the
+/// valid types, rather than silently returning "No results found". A silent
+/// false-empty on a bad filter masked a P0 verification signal (hq-2q7).
+#[test]
+fn search_invalid_type_errors_with_valid_list() {
+    let project = TestProject::new();
+    TestProject::bobbin_cmd()
+        .arg("init")
+        .arg(project.path())
+        .output()
+        .expect("init failed");
+
+    TestProject::bobbin_cmd()
+        .args(["search", "anything", "--type", "bogus"])
+        .arg(project.path())
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("Unknown chunk type")
+                .and(predicate::str::contains("function"))
+                .and(predicate::str::contains("commit")),
+        );
+}
+
+/// bo-92t companion: `--type bead` is a VALID alias for the issue chunk type, so
+/// it must NOT be rejected as invalid. (The empty results observed in hq-2q7 came
+/// from no indexed beads — see bo-f61 — not from an invalid filter.)
+#[test]
+fn search_type_bead_is_valid_alias() {
+    let project = TestProject::new();
+    TestProject::bobbin_cmd()
+        .arg("init")
+        .arg(project.path())
+        .output()
+        .expect("init failed");
+
+    // No index yet, so this returns the empty-index message, NOT an
+    // "Unknown chunk type" error — proving `bead` parses as a valid type.
+    TestProject::bobbin_cmd()
+        .args(["search", "anything", "--type", "bead"])
+        .arg(project.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Unknown chunk type").not());
+}


### PR DESCRIPTION
Clears the open bug backlog assigned via bo-s6kh. All five fixes have tests; full unit suite (832) + cli_index/cli_search integration pass; file-size gate clean.

## Fixes

**bo-f61** (P2) — `bobbin index` `total_files==0` fast-return preceded the git-commits and beads blocks, so a 0-change index (dedicated `--include-beads` pass or no-change incremental) silently skipped bead/commit indexing. Now computes the commits/beads flags up front and only fast-returns when neither is enabled; otherwise falls through (file loops are 0-file no-ops). Test: `index_zero_files_still_indexes_commits`.

**bo-92t** (P2) — Premise was stale: `--type` is already validated on all three paths (CLI, HTTP→400, MCP) and `bead` is a valid alias for `ChunkType::Issue`. The hq-2q7 "silent empty" was a legitimately-empty valid filter masking bo-f61, not an invalid filter. Locked the behavior with regression tests and brought the MCP error message to parity with the CLI (now lists valid types). Tests: `search_invalid_type_errors_with_valid_list`, `search_type_bead_is_valid_alias`.

**bo-ewk** (P3) — Release CI macos-x86 Package step failed because the osx-x86_64 ONNX tarball entries carry a leading `./` component (Linux/arm64 don't), so `tar --strip-components=1` stripped `.` instead of the version dir, leaving `lib/` one level too deep. Dropped `--strip-components`, locate `lib/` wherever it lands, added `curl --fail`, and guard that ≥1 lib is copied. Verified against all three release tarballs. (Not a hang — the 1h6m was the Build step.)

**bo-b0nn** (P3) — `doc_demotion` had disagreeing defaults (SearchConfig=0.3 effective, ContextConfig::default()=0.5) + stale "Default: 0.5" comments. Aligned ContextConfig default to 0.3 (the single source of truth every production path already applies); no behavior change. Test: `test_doc_demotion_single_source_of_truth`.

**bo-ruuc** (P3) — `bobbin context` hardcoded `repo_affinity_boost=2.0` instead of reading `config.hooks.repo_affinity_boost`. Now sourced from config. Test: `test_hooks_repo_affinity_boost_custom`. Follow-up filed (bo-u962) for the remaining hardcoded MCP/HTTP sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)