### PR TITLE
feat(telemetry): extend bead_lineage — feature_id + numstat + symbols (bo-xrsy)

### DIFF
--- a/src/cli/bead.rs
+++ b/src/cli/bead.rs
@@ -7,7 +7,8 @@ use std::process::Command;
 
 use super::OutputConfig;
 use crate::config::Config;
-use crate::storage::sqlite::{BeadLineageRecord, MetadataStore, NewBeadLineage};
+use crate::index::Parser;
+use crate::storage::sqlite::{BeadLineageRecord, MetadataStore, NewBeadLineage, TouchedSymbol};
 
 #[derive(Args)]
 pub struct BeadArgs {
@@ -76,6 +77,10 @@ struct HistoryEntry {
     bundle_slugs: Option<String>,
     touched_files: Vec<String>,
     action_type: Option<String>,
+    feature_id: Option<String>,
+    lines_added: Option<i64>,
+    lines_deleted: Option<i64>,
+    touched_symbols: Vec<TouchedSymbol>,
 }
 
 impl From<BeadLineageRecord> for HistoryEntry {
@@ -89,6 +94,10 @@ impl From<BeadLineageRecord> for HistoryEntry {
             bundle_slugs: r.bundle_slugs,
             touched_files: r.touched_files,
             action_type: r.action_type,
+            feature_id: r.feature_id,
+            lines_added: r.lines_added,
+            lines_deleted: r.lines_deleted,
+            touched_symbols: r.touched_symbols,
         }
     }
 }
@@ -108,25 +117,49 @@ pub async fn run(args: BeadArgs, output: OutputConfig) -> Result<()> {
             bundles,
             action,
         } => {
-            // Resolve touched files: explicit --files wins, else derive from commit.
-            let touched_files: Vec<String> = if let Some(f) = files {
-                f.split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect()
-            } else if let Some(ref sha) = commit {
-                files_in_commit(&repo_root, sha).unwrap_or_default()
-            } else {
-                Vec::new()
+            // Resolve touched files + line counts: explicit --files wins (no
+            // line counts available), else derive from the commit via numstat.
+            let (touched_files, lines_added, lines_deleted): (Vec<String>, Option<i64>, Option<i64>) =
+                if let Some(f) = files {
+                    let parsed = f
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    (parsed, None, None)
+                } else if let Some(ref sha) = commit {
+                    match commit_numstat(&repo_root, sha) {
+                        Ok((files, added, deleted)) => (files, Some(added), Some(deleted)),
+                        Err(_) => (Vec::new(), None, None),
+                    }
+                } else {
+                    (Vec::new(), None, None)
+                };
+
+            // bundle_slugs (edge E2): explicit --bundles wins, else derive from
+            // the bead's `b:<slug>` labels.
+            let bundle_slugs = bundles.or_else(|| bundle_slugs_from_labels(&bead_id));
+
+            // feature_id (edge E1 'implements'): walk deps to a feature ancestor.
+            let feature_id = resolve_feature_id(&bead_id);
+
+            // touched_symbols (best-effort): parse each committed file version.
+            let touched_symbols = match commit.as_ref() {
+                Some(sha) => extract_touched_symbols(&repo_root, sha, &touched_files),
+                None => Vec::new(),
             };
 
             let id = store.record_bead_lineage(&NewBeadLineage {
                 bead_id: bead_id.clone(),
                 bead_type,
                 commit_sha: commit.clone(),
-                bundle_slugs: bundles,
+                bundle_slugs,
                 touched_files: touched_files.clone(),
                 action_type: Some(action),
+                feature_id,
+                lines_added,
+                lines_deleted,
+                touched_symbols,
             })?;
 
             if output.json {
@@ -191,11 +224,13 @@ pub async fn run(args: BeadArgs, output: OutputConfig) -> Result<()> {
     Ok(())
 }
 
-/// Return the list of files changed in a commit using git, repo-relative.
-fn files_in_commit(repo_root: &Path, sha: &str) -> Result<Vec<String>> {
+/// Files changed in a commit plus aggregate line counts, via `git show
+/// --numstat`. Each numstat line is `added<TAB>deleted<TAB>path`; binary files
+/// emit `-` for added/deleted and contribute 0. Paths are repo-relative.
+fn commit_numstat(repo_root: &Path, sha: &str) -> Result<(Vec<String>, i64, i64)> {
     let out = Command::new("git")
         .current_dir(repo_root)
-        .args(["show", "--name-only", "--pretty=format:", sha])
+        .args(["show", "--numstat", "--pretty=format:", sha])
         .output()
         .context("Failed to run git")?;
     if !out.status.success() {
@@ -205,10 +240,178 @@ fn files_in_commit(repo_root: &Path, sha: &str) -> Result<Vec<String>> {
             String::from_utf8_lossy(&out.stderr)
         ));
     }
-    let files = String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty())
+    Ok(parse_numstat(&String::from_utf8_lossy(&out.stdout)))
+}
+
+/// Parse `git --numstat` output into (files, total_added, total_deleted). Each
+/// line is `added<TAB>deleted<TAB>path`; binary files emit `-` and contribute 0.
+fn parse_numstat(stdout: &str) -> (Vec<String>, i64, i64) {
+    let mut files = Vec::new();
+    let mut total_added = 0i64;
+    let mut total_deleted = 0i64;
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(3, '\t');
+        let added = parts.next().unwrap_or("-");
+        let deleted = parts.next().unwrap_or("-");
+        let path = match parts.next() {
+            Some(p) if !p.trim().is_empty() => p.trim().to_string(),
+            _ => continue,
+        };
+        // Binary files report '-'; parse failures count as 0.
+        total_added += added.parse::<i64>().unwrap_or(0);
+        total_deleted += deleted.parse::<i64>().unwrap_or(0);
+        files.push(path);
+    }
+    (files, total_added, total_deleted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_numstat_basic() {
+        let out = "10\t2\tsrc/a.rs\n5\t0\tsrc/b.rs\n";
+        let (files, added, deleted) = parse_numstat(out);
+        assert_eq!(files, vec!["src/a.rs", "src/b.rs"]);
+        assert_eq!(added, 15);
+        assert_eq!(deleted, 2);
+    }
+
+    #[test]
+    fn test_parse_numstat_binary_counts_zero() {
+        // Binary files emit '-' for both columns and must contribute 0.
+        let out = "-\t-\tassets/logo.png\n3\t1\tsrc/a.rs\n";
+        let (files, added, deleted) = parse_numstat(out);
+        assert_eq!(files, vec!["assets/logo.png", "src/a.rs"]);
+        assert_eq!(added, 3);
+        assert_eq!(deleted, 1);
+    }
+
+    #[test]
+    fn test_parse_numstat_empty() {
+        let (files, added, deleted) = parse_numstat("\n\n");
+        assert!(files.is_empty());
+        assert_eq!(added, 0);
+        assert_eq!(deleted, 0);
+    }
+}
+
+/// Fetch a bead as JSON via `bd show <id> --json`. bd may emit a single object
+/// or a one-element array; this normalizes to the first object. Best-effort:
+/// returns None on any failure so lineage recording never hard-fails on
+/// telemetry enrichment.
+fn bead_json(bead_id: &str) -> Option<serde_json::Value> {
+    let out = Command::new("bd")
+        .args(["show", bead_id, "--json"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    match v {
+        serde_json::Value::Array(arr) => arr.into_iter().next(),
+        other => Some(other),
+    }
+}
+
+/// Derive bundle slugs from the bead's `b:<slug>` labels (edge E2). Best-effort:
+/// returns None if bd is unavailable or no bundle labels are present.
+fn bundle_slugs_from_labels(bead_id: &str) -> Option<String> {
+    let v = bead_json(bead_id)?;
+    let labels = v.get("labels")?.as_array()?;
+    let slugs: Vec<String> = labels
+        .iter()
+        .filter_map(|l| l.as_str())
+        .filter_map(|l| l.strip_prefix("b:"))
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
         .collect();
-    Ok(files)
+    if slugs.is_empty() {
+        None
+    } else {
+        Some(slugs.join(","))
+    }
+}
+
+/// Resolve the feature ancestor of a bead by walking its dependency graph (edge
+/// E1 'implements'). Returns the id of the first `feature`-typed ancestor found,
+/// or None. Best-effort: cycle-guarded (visited set), depth-capped at 10, and
+/// NULL on any bd failure.
+fn resolve_feature_id(bead_id: &str) -> Option<String> {
+    use std::collections::HashSet;
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut frontier: Vec<String> = vec![bead_id.to_string()];
+    let mut depth = 0;
+    while !frontier.is_empty() && depth < 10 {
+        let mut next: Vec<String> = Vec::new();
+        for id in frontier {
+            if !visited.insert(id.clone()) {
+                continue;
+            }
+            let v = match bead_json(&id) {
+                Some(v) => v,
+                None => continue,
+            };
+            if let Some(deps) = v.get("dependencies").and_then(|d| d.as_array()) {
+                for dep in deps {
+                    let dep_id = match dep.get("id").and_then(|i| i.as_str()) {
+                        Some(i) => i,
+                        None => continue,
+                    };
+                    let dep_type = dep
+                        .get("issue_type")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
+                    if dep_type == "feature" {
+                        return Some(dep_id.to_string());
+                    }
+                    next.push(dep_id.to_string());
+                }
+            }
+        }
+        frontier = next;
+        depth += 1;
+    }
+    None
+}
+
+/// Best-effort symbol extraction for a commit's changed files. For each file we
+/// parse its committed version (`git show <sha>:<path>`) and collect named
+/// chunks. Binary / unparseable / deleted files are skipped silently.
+fn extract_touched_symbols(repo_root: &Path, sha: &str, files: &[String]) -> Vec<TouchedSymbol> {
+    let mut parser = match Parser::new() {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for file in files {
+        let blob = Command::new("git")
+            .current_dir(repo_root)
+            .args(["show", &format!("{}:{}", sha, file)])
+            .output();
+        let content = match blob {
+            Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).into_owned(),
+            _ => continue, // deleted / binary / missing at this revision
+        };
+        let chunks = match parser.parse_file(Path::new(file), &content) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        for chunk in chunks {
+            if let Some(name) = chunk.name {
+                out.push(TouchedSymbol {
+                    file: file.clone(),
+                    symbol: name,
+                    kind: chunk.chunk_type.to_string(),
+                });
+            }
+        }
+    }
+    out
 }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::types::FileCoupling;
@@ -74,6 +75,41 @@ impl MetadataStore {
         "#,
         )?;
 
+        self.migrate_bead_lineage()?;
+
+        Ok(())
+    }
+
+    /// Idempotently add columns introduced after the initial bead_lineage schema
+    /// (telemetry Phase 0, bo-xrsy). SQLite has no `ADD COLUMN IF NOT EXISTS`, so
+    /// we inspect `PRAGMA table_info` and only ALTER for genuinely-missing
+    /// columns. Errors other than the additions themselves propagate — we do not
+    /// blind-try-and-ignore. `bundle_slugs` already exists in the base schema and
+    /// is intentionally absent here (this migration only adds new columns).
+    fn migrate_bead_lineage(&self) -> Result<()> {
+        let mut existing = std::collections::HashSet::new();
+        {
+            let mut stmt = self.conn.prepare("PRAGMA table_info(bead_lineage)")?;
+            let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+            for r in rows {
+                existing.insert(r?);
+            }
+        }
+        // (column, SQL type) — additive only.
+        let additions = [
+            ("feature_id", "TEXT"),
+            ("lines_added", "INTEGER"),
+            ("lines_deleted", "INTEGER"),
+            ("touched_symbols", "TEXT"),
+        ];
+        for (col, ty) in additions {
+            if !existing.contains(col) {
+                self.conn.execute(
+                    &format!("ALTER TABLE bead_lineage ADD COLUMN {} {}", col, ty),
+                    [],
+                )?;
+            }
+        }
         Ok(())
     }
 
@@ -270,10 +306,13 @@ impl MetadataStore {
     pub fn record_bead_lineage(&self, rec: &NewBeadLineage) -> Result<i64> {
         let touched_files_json = serde_json::to_string(&rec.touched_files)
             .unwrap_or_else(|_| "[]".to_string());
+        let touched_symbols_json = serde_json::to_string(&rec.touched_symbols)
+            .unwrap_or_else(|_| "[]".to_string());
         self.conn.execute(
             r#"INSERT INTO bead_lineage
-                   (bead_id, bead_type, commit_sha, bundle_slugs, touched_files, action_type)
-               VALUES (?1, ?2, ?3, ?4, ?5, ?6)"#,
+                   (bead_id, bead_type, commit_sha, bundle_slugs, touched_files, action_type,
+                    feature_id, lines_added, lines_deleted, touched_symbols)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)"#,
             rusqlite::params![
                 rec.bead_id,
                 rec.bead_type,
@@ -281,6 +320,10 @@ impl MetadataStore {
                 rec.bundle_slugs,
                 touched_files_json,
                 rec.action_type,
+                rec.feature_id,
+                rec.lines_added,
+                rec.lines_deleted,
+                touched_symbols_json,
             ],
         )?;
         Ok(self.conn.last_insert_rowid())
@@ -295,7 +338,8 @@ impl MetadataStore {
         limit: usize,
     ) -> Result<Vec<BeadLineageRecord>> {
         let mut sql = String::from(
-            "SELECT id, created_at, bead_id, bead_type, commit_sha, bundle_slugs, touched_files, action_type
+            "SELECT id, created_at, bead_id, bead_type, commit_sha, bundle_slugs, touched_files, action_type,
+                    feature_id, lines_added, lines_deleted, touched_symbols
              FROM bead_lineage",
         );
         let mut conditions: Vec<String> = Vec::new();
@@ -323,6 +367,10 @@ impl MetadataStore {
                 let touched_files = touched_json
                     .and_then(|j| serde_json::from_str::<Vec<String>>(&j).ok())
                     .unwrap_or_default();
+                let symbols_json: Option<String> = row.get(11)?;
+                let touched_symbols = symbols_json
+                    .and_then(|j| serde_json::from_str::<Vec<TouchedSymbol>>(&j).ok())
+                    .unwrap_or_default();
                 Ok(BeadLineageRecord {
                     id: row.get(0)?,
                     created_at: row.get(1)?,
@@ -332,11 +380,26 @@ impl MetadataStore {
                     bundle_slugs: row.get(5)?,
                     touched_files,
                     action_type: row.get(7)?,
+                    feature_id: row.get(8)?,
+                    lines_added: row.get(9)?,
+                    lines_deleted: row.get(10)?,
+                    touched_symbols,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
         Ok(rows)
     }
+}
+
+/// A symbol touched by a commit's changeset (telemetry Phase 0, bo-xrsy).
+/// Carries file attribution so the reconcile/predict loops (bo-mu4m/bo-6i55) can
+/// map a bead to the named entities it changed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TouchedSymbol {
+    pub file: String,
+    pub symbol: String,
+    /// Chunk kind (function | method | struct | ...), from the parser.
+    pub kind: String,
 }
 
 /// Input for recording a bead lineage entry. `id`/`created_at` are assigned by
@@ -349,6 +412,14 @@ pub struct NewBeadLineage {
     pub bundle_slugs: Option<String>,
     pub touched_files: Vec<String>,
     pub action_type: Option<String>,
+    /// Feature ancestor resolved via bd dep-walk (edge E1 'implements').
+    pub feature_id: Option<String>,
+    /// Aggregate lines added across the changeset (numstat).
+    pub lines_added: Option<i64>,
+    /// Aggregate lines deleted across the changeset (numstat).
+    pub lines_deleted: Option<i64>,
+    /// Named symbols touched by the changeset (best-effort parse).
+    pub touched_symbols: Vec<TouchedSymbol>,
 }
 
 /// A stored bead→commit lineage record.
@@ -362,6 +433,10 @@ pub struct BeadLineageRecord {
     pub bundle_slugs: Option<String>,
     pub touched_files: Vec<String>,
     pub action_type: Option<String>,
+    pub feature_id: Option<String>,
+    pub lines_added: Option<i64>,
+    pub lines_deleted: Option<i64>,
+    pub touched_symbols: Vec<TouchedSymbol>,
 }
 
 #[cfg(test)]
@@ -564,6 +639,14 @@ mod tests {
                 bundle_slugs: Some("search-reranking".to_string()),
                 touched_files: vec!["src/search/weights.rs".to_string(), "src/a.rs".to_string()],
                 action_type: Some("linked".to_string()),
+                feature_id: Some("bo-feat".to_string()),
+                lines_added: Some(42),
+                lines_deleted: Some(7),
+                touched_symbols: vec![TouchedSymbol {
+                    file: "src/search/weights.rs".to_string(),
+                    symbol: "rerank".to_string(),
+                    kind: "function".to_string(),
+                }],
             })
             .unwrap();
 
@@ -573,6 +656,13 @@ mod tests {
         assert_eq!(all[0].commit_sha.as_deref(), Some("deadbeef"));
         assert_eq!(all[0].touched_files.len(), 2);
         assert!(all[0].touched_files.contains(&"src/a.rs".to_string()));
+        // New telemetry Phase 0 fields round-trip through record -> list.
+        assert_eq!(all[0].feature_id.as_deref(), Some("bo-feat"));
+        assert_eq!(all[0].lines_added, Some(42));
+        assert_eq!(all[0].lines_deleted, Some(7));
+        assert_eq!(all[0].touched_symbols.len(), 1);
+        assert_eq!(all[0].touched_symbols[0].symbol, "rerank");
+        assert_eq!(all[0].touched_symbols[0].kind, "function");
 
         // Filter by bead id
         let by_bead = store.list_bead_lineage(Some("bo-abc"), None, 10).unwrap();
@@ -582,6 +672,71 @@ mod tests {
         // Filter by commit
         let by_commit = store.list_bead_lineage(None, Some("deadbeef"), 10).unwrap();
         assert_eq!(by_commit.len(), 1);
+    }
+
+    #[test]
+    fn test_bead_lineage_migration_idempotent() {
+        // Opening the same DB twice must not error or duplicate columns: the
+        // second open re-runs migrate_bead_lineage against an already-migrated
+        // table.
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("migrate.db");
+        {
+            let _store = MetadataStore::open(&db_path).unwrap();
+        }
+        let store = MetadataStore::open(&db_path).unwrap();
+
+        // The new columns exist exactly once.
+        let cols: Vec<String> = {
+            let mut stmt = store
+                .conn
+                .prepare("PRAGMA table_info(bead_lineage)")
+                .unwrap();
+            let rows = stmt
+                .query_map([], |row| row.get::<_, String>(1))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            rows
+        };
+        for expected in ["feature_id", "lines_added", "lines_deleted", "touched_symbols"] {
+            assert_eq!(
+                cols.iter().filter(|c| c.as_str() == expected).count(),
+                1,
+                "column {expected} should exist exactly once"
+            );
+        }
+    }
+
+    #[test]
+    fn test_bead_lineage_migrates_legacy_table() {
+        // A DB created with only the original columns (pre-bo-xrsy) must gain the
+        // new columns on next open, and existing rows survive with NULL telemetry.
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("legacy.db");
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                r#"CREATE TABLE bead_lineage (
+                       id INTEGER PRIMARY KEY AUTOINCREMENT,
+                       created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+                       bead_id TEXT NOT NULL,
+                       bead_type TEXT,
+                       commit_sha TEXT,
+                       bundle_slugs TEXT,
+                       touched_files TEXT,
+                       action_type TEXT
+                   );
+                   INSERT INTO bead_lineage (bead_id, commit_sha) VALUES ('bo-old', 'cafe');"#,
+            )
+            .unwrap();
+        }
+        let store = MetadataStore::open(&db_path).unwrap();
+        let rows = store.list_bead_lineage(Some("bo-old"), None, 10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].feature_id, None);
+        assert_eq!(rows[0].lines_added, None);
+        assert!(rows[0].touched_symbols.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## bo-xrsy — telemetry Phase 0: materialize entity edges at write time

First bead in the `bo-zbwf` backlog (feature↔code↔bug reconcile/predict north-star). Extends `bobbin bead link` / `record_bead_lineage` so lineage rows carry the edges later layers (bo-mu4m reconcile, bo-6i55 predict) need.

### What changed
- **feature_id** (edge E1 *implements*): walk the bead's dependency graph to the first `feature`-typed ancestor via `bd show --json`. Depth-capped at 10, cycle-guarded, memoized within a call, best-effort NULL on any bd failure.
- **bundle_slugs** (edge E2): auto-populate from the bead's `b:<slug>` labels when `--bundles` isn't passed explicitly.
- **numstat**: `files_in_commit` → `git show --numstat`; aggregate `lines_added`/`lines_deleted`. Binary files (`-`) count as 0. `touched_files` list preserved.
- **touched_symbols** (JSON): parse each file's committed version (`git show <sha>:<path>`) and collect named chunks as `{file, symbol, kind}`. Best-effort: binary/unparseable/deleted files skipped.

### Schema
Additive, idempotent migration in `init_schema`: read `PRAGMA table_info(bead_lineage)`, `ALTER TABLE ADD COLUMN` only for genuinely-missing columns (no versioning framework exists; SQLite has no `ADD COLUMN IF NOT EXISTS`). Does **not** blind-try-and-ignore. `bundle_slugs` already existed.

### Tests
- migration idempotency (open twice, columns exist exactly once)
- legacy-table upgrade (pre-bo-xrsy schema gains columns, old rows survive with NULL telemetry)
- new-field round-trip through record → list
- numstat parsing incl. binary `-` → 0

837 unit + integration tests pass locally. `cargo build` clean (no new warnings).

### Note for reviewer
`src/storage/sqlite.rs` is now 772 lines (was 617 on main, already over the 500 soft limit and not in the large-file allowlist — pre-existing, not introduced here). Not gated by CI or any installed hook. Flagging as a follow-up split candidate; left out of scope for this bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)