### PR TITLE
feat(git): coupling score weights -> config (bo-y1kd)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,6 +234,8 @@ semantic_weight = 0.7
 coupling_enabled = true
 coupling_depth = 1000
 coupling_threshold = 3
+coupling_freq_weight = 0.7   # frequency vs recency split (recency = 1 - this)
+coupling_recency_days = 30.0 # recency decay knee: N days old -> 0.5 recency score
 ```
 
 ## Hybrid Search (RRF)

--- a/src/cli/calibrate.rs
+++ b/src/cli/calibrate.rs
@@ -738,8 +738,10 @@ fn reindex_coupling(
     db_path: &std::path::Path,
     depth: usize,
     threshold: u32,
+    freq_weight: f32,
+    recency_days: f32,
 ) -> Result<()> {
-    let couplings = git.analyze_coupling(depth, threshold)?;
+    let couplings = git.analyze_coupling(depth, threshold, freq_weight, recency_days)?;
     let ms = MetadataStore::open(db_path)?;
     ms.clear_coupling()?;
     ms.begin_transaction()?;
@@ -1385,7 +1387,14 @@ async fn run_full_sweep(
                 });
             }
         }
-        reindex_coupling(git, db_path, depth, config.git.coupling_threshold)?;
+        reindex_coupling(
+            git,
+            db_path,
+            depth,
+            config.git.coupling_threshold,
+            config.git.coupling_freq_weight,
+            config.git.coupling_recency_days,
+        )?;
 
         // Run probes with this coupling depth
         let prog = progress_path(repo_root);
@@ -1423,7 +1432,14 @@ async fn run_full_sweep(
             original_coupling_depth
         );
     }
-    reindex_coupling(git, db_path, original_coupling_depth, config.git.coupling_threshold)?;
+    reindex_coupling(
+        git,
+        db_path,
+        original_coupling_depth,
+        config.git.coupling_threshold,
+        config.git.coupling_freq_weight,
+        config.git.coupling_recency_days,
+    )?;
 
     Ok(all_results)
 }

--- a/src/cli/index.rs
+++ b/src/cli/index.rs
@@ -599,6 +599,8 @@ pub async fn run(args: IndexArgs, output: OutputConfig) -> Result<()> {
                     match analyzer.analyze_coupling(
                         config.git.coupling_depth,
                         config.git.coupling_threshold,
+                        config.git.coupling_freq_weight,
+                        config.git.coupling_recency_days,
                     ) {
                         Ok(couplings) => {
                             let mut count = 0;

--- a/src/config.rs
+++ b/src/config.rs
@@ -330,6 +330,14 @@ pub struct GitConfig {
     pub coupling_depth: usize,
     /// Minimum co-changes to establish coupling
     pub coupling_threshold: u32,
+    /// Weight on co-change frequency in the coupling score (0.0–1.0). The
+    /// recency component is weighted `1.0 - coupling_freq_weight`. Default: 0.7
+    /// (70% frequency, 30% recency).
+    pub coupling_freq_weight: f32,
+    /// Recency knee in days for coupling score decay: a pair last changed
+    /// together `coupling_recency_days` ago scores 0.5 on the recency component
+    /// (`1/(1 + days/coupling_recency_days)`). Default: 30.0.
+    pub coupling_recency_days: f32,
     /// Enable semantic commit indexing (embed commit messages for search)
     pub commits_enabled: bool,
     /// How many commits back to index for semantic search (0 = all)
@@ -342,6 +350,8 @@ impl Default for GitConfig {
             coupling_enabled: true,
             coupling_depth: 5000,
             coupling_threshold: 3,
+            coupling_freq_weight: 0.7,
+            coupling_recency_days: 30.0,
             commits_enabled: true,
             commits_depth: 0,
         }

--- a/src/index/git.rs
+++ b/src/index/git.rs
@@ -114,7 +114,13 @@ impl GitAnalyzer {
     }
 
     /// Analyze git history to find files that change together
-    pub fn analyze_coupling(&self, depth: usize, threshold: u32) -> Result<Vec<FileCoupling>> {
+    pub fn analyze_coupling(
+        &self,
+        depth: usize,
+        threshold: u32,
+        freq_weight: f32,
+        recency_days: f32,
+    ) -> Result<Vec<FileCoupling>> {
         // Get commit log with files changed
         // Format: COMMIT:<hash>:<timestamp>
         // followed by list of files
@@ -211,7 +217,14 @@ impl GitAnalyzer {
                 FileCoupling {
                     file_a,
                     file_b,
-                    score: calculate_coupling_score(count, max_co_changes, last_co_change, now),
+                    score: calculate_coupling_score(
+                        count,
+                        max_co_changes,
+                        last_co_change,
+                        now,
+                        freq_weight,
+                        recency_days,
+                    ),
                     co_changes: count,
                     last_co_change,
                 }
@@ -859,12 +872,19 @@ fn parse_range_spec(spec: &str) -> (u32, u32) {
     }
 }
 
-/// Calculate coupling score based on frequency and recency
+/// Calculate coupling score based on frequency and recency.
+///
+/// `freq_weight` is the weight on the normalized co-change count (0.0–1.0); the
+/// recency component is weighted `1.0 - freq_weight`. `recency_days` is the knee
+/// of the recency decay: a pair last changed `recency_days` ago scores 0.5 on
+/// recency. See `[git].coupling_freq_weight` / `coupling_recency_days`.
 fn calculate_coupling_score(
     co_changes: u32,
     max_co_changes: u32,
     last_co_change: i64,
     now: i64,
+    freq_weight: f32,
+    recency_days: f32,
 ) -> f32 {
     if max_co_changes == 0 {
         return 0.0;
@@ -873,17 +893,16 @@ fn calculate_coupling_score(
     // Frequency score: normalized count (0.0 - 1.0)
     let freq_score = co_changes as f32 / max_co_changes as f32;
 
-    // Recency score: decay based on days since last co-change
-    // Decay factor: 0.99 per day? Or simpler: 1 / (1 + days)
+    // Recency score: slow decay based on days since last co-change.
+    // At `recency_days` old the score is 0.5; at 0 days it is 1.0.
+    // Guard against a non-positive knee collapsing the decay.
+    let knee = if recency_days > 0.0 { recency_days } else { 30.0 };
     let days_diff = ((now - last_co_change) as f32 / 86400.0).max(0.0);
-    // Use a slow decay: at 30 days, score is ~0.5. at 0 days, score is 1.0
-    // 30 days * k = 1 => k = 1/30?
-    // Let's use 1 / (1 + days/30)
-    let recency_score = 1.0 / (1.0 + days_diff / 30.0);
+    let recency_score = 1.0 / (1.0 + days_diff / knee);
 
-    // Weighted combination: 70% frequency, 30% recency
-    // This emphasizes pairs that change often, with a boost if they changed recently
-    0.7 * freq_score + 0.3 * recency_score
+    // Weighted combination: emphasizes pairs that change often, with a boost if
+    // they changed recently. Recency weight is the complement of freq_weight.
+    freq_weight * freq_score + (1.0 - freq_weight) * recency_score
 }
 
 /// Parse git blame --porcelain output into BlameEntry records.
@@ -932,22 +951,36 @@ mod tests {
         let now = 10000;
         let max_co_changes = 10;
 
+        // Default weights: 0.7 frequency, 0.3 recency, 30-day knee.
+        let fw = 0.7;
+        let rd = 30.0;
+
         // Case 1: High frequency, recent
-        let score1 = calculate_coupling_score(10, max_co_changes, now, now);
+        let score1 = calculate_coupling_score(10, max_co_changes, now, now, fw, rd);
         // freq = 1.0, recency = 1.0 -> 1.0
         assert!((score1 - 1.0).abs() < 0.001);
 
         // Case 2: Low frequency, recent
-        let score2 = calculate_coupling_score(1, max_co_changes, now, now);
+        let score2 = calculate_coupling_score(1, max_co_changes, now, now, fw, rd);
         // freq = 0.1, recency = 1.0 -> 0.07 + 0.3 = 0.37
         assert!((score2 - 0.37).abs() < 0.001);
 
         // Case 3: High frequency, old
         // 30 days old = 2592000 seconds
         let old = now - 30 * 86400;
-        let score3 = calculate_coupling_score(10, max_co_changes, old, now);
+        let score3 = calculate_coupling_score(10, max_co_changes, old, now, fw, rd);
         // freq = 1.0, recency = 1/(1+1) = 0.5 -> 0.7 + 0.15 = 0.85
         assert!((score3 - 0.85).abs() < 0.001);
+
+        // Case 4: Custom weights — recency-dominant (freq_weight = 0.2).
+        // freq = 1.0, recency = 0.5 -> 0.2 + 0.4 = 0.6
+        let score4 = calculate_coupling_score(10, max_co_changes, old, now, 0.2, rd);
+        assert!((score4 - 0.6).abs() < 0.001);
+
+        // Case 5: Custom knee — 60-day knee makes 30-day-old pairs decay less.
+        // freq = 1.0, recency = 1/(1+0.5) = 0.667 -> 0.7 + 0.3*0.667 = 0.9
+        let score5 = calculate_coupling_score(10, max_co_changes, old, now, fw, 60.0);
+        assert!((score5 - 0.9).abs() < 0.001);
     }
 
     #[test]


### PR DESCRIPTION
## What

`calculate_coupling_score` (src/index/git.rs) hardcoded `0.7*freq + 0.3*recency` with a 30-day recency knee. Surfaces both as `[git]` config:

- `coupling_freq_weight` (default **0.7**; recency weight = `1 - this`)
- `coupling_recency_days` (default **30.0**; recency decay knee — a pair last changed N days ago scores 0.5 on recency)

Affects `bobbin related` + PPR seeding scores.

## How

Threaded the two weights through `analyze_coupling` → `calculate_coupling_score`, and through `reindex_coupling` in the calibrate path. Index + calibrate call sites read from `config.git`.

## Safety

- **Defaults reproduce prior behavior exactly** — zero score change with default config.
- Non-positive `coupling_recency_days` falls back to 30 to guard the decay denominator.

## Tests

`test_calculate_coupling_score` extended: default weights (3 cases, unchanged), custom recency-dominant weights, and custom 60-day knee. Config round-trip + legacy-git-config tests green. Docs `[git]` block updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)