### PR TITLE
feat(causality): sharpen bug_causality with git-blame (bo-8nmm)

### DIFF
--- a/src/cli/bead.rs
+++ b/src/cli/bead.rs
@@ -214,7 +214,7 @@ pub async fn run(args: BeadArgs, output: OutputConfig) -> Result<()> {
         }
 
         BeadCommand::ReconstructCausality { bug, limit } => {
-            run_reconstruct_causality(&store, bug.as_deref(), limit, &output)?;
+            run_reconstruct_causality(&repo_root, &store, bug.as_deref(), limit, &output)?;
         }
 
         BeadCommand::History {
@@ -504,24 +504,30 @@ struct CausalityOutput {
     rows: usize,
 }
 
-/// Reconstruct bug causality and populate `bug_causality` (bo-s1kb).
+/// Reconstruct bug causality and populate `bug_causality` (bo-s1kb, bo-8nmm).
 ///
 /// For each bug bead: gather the files its fix touched, find the most-recent
 /// prior commit touching each such file (the candidate culprit), score
-/// confidence by how much of the fix's changeset that commit overlaps, and
-/// upsert one row per (bug, culprit, file). Idempotent via the table's UNIQUE
-/// constraint, so periodic re-runs refresh rather than duplicate.
+/// confidence by how much of the fix's changeset that commit overlaps, then
+/// *sharpen* each file with git blame — blaming the exact lines the fix removed
+/// against the fix's parent yields the precise introducing commit at higher
+/// confidence. Upserts one row per (bug, culprit, file); idempotent via the
+/// table's UNIQUE constraint, so periodic re-runs refresh rather than duplicate.
 ///
-/// Scope (v1): the recency+overlap heuristic over `bead_lineage`. Git-blame
-/// sharpening of the exact introducing commit and `change_events` outcome
-/// labeling are deferred (see bo-s1kb design notes) — neither blocks the
-/// supervised signal this table provides.
+/// Layering: blame (bo-8nmm) is the sharp signal and replaces the recency+overlap
+/// heuristic (bo-s1kb) per file where available, falling back to it otherwise
+/// (pure additions, new files, root commits, non-git trees). `change_events`
+/// outcome labeling remains deferred (see bo-s1kb design notes).
 fn run_reconstruct_causality(
+    repo_root: &Path,
     store: &MetadataStore,
     bug: Option<&str>,
     limit: usize,
     output: &OutputConfig,
 ) -> Result<()> {
+    // Git-blame sharpening (bo-8nmm) needs a repo handle; absence (e.g. running
+    // against a non-git tree) degrades gracefully to the recency+overlap path.
+    let git = crate::index::GitAnalyzer::new(repo_root).ok();
     // Resolve the set of bug beads to process.
     let bug_ids: Vec<String> = match bug {
         Some(b) => vec![b.to_string()],
@@ -568,12 +574,40 @@ fn run_reconstruct_causality(
             .filter(|t| &t.bead_id != bug_id)
             .collect();
 
-        let candidates = reconstruct_culprits(&fix_files, &prior);
+        let fallback = reconstruct_culprits(&fix_files, &prior);
+
+        // Sharpen with git blame (bo-8nmm): for each fix commit, blame the lines
+        // it removed against the parent to find the exact introducing commit.
+        // Per-file culprit shas accumulate across all of the bug's fix commits.
+        let mut blame_map: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        if let Some(git) = git.as_ref() {
+            for row in &fix_rows {
+                let Some(sha) = row.commit_sha.as_deref().filter(|s| !s.is_empty()) else {
+                    continue;
+                };
+                for file in &row.touched_files {
+                    if let Ok(entries) = git.blame_fix_culprits(sha, file) {
+                        if entries.is_empty() {
+                            continue;
+                        }
+                        let shas = blame_map.entry(file.clone()).or_default();
+                        for e in entries {
+                            shas.push(e.commit_hash);
+                        }
+                    }
+                }
+            }
+        }
+
+        let candidates = merge_causality(fallback, &blame_map);
         for c in &candidates {
             store.record_bug_causality(&NewBugCausality {
                 bug_id: bug_id.clone(),
                 culprit_sha: Some(c.culprit_sha.clone()),
-                culprit_bead_id: Some(c.culprit_bead_id.clone()),
+                // Blame-derived culprits know only the sha, not a bead.
+                culprit_bead_id: Some(c.culprit_bead_id.clone())
+                    .filter(|b| !b.is_empty()),
                 file: Some(c.file.clone()),
                 confidence: Some(c.confidence),
             })?;
@@ -671,6 +705,71 @@ fn reconstruct_culprits(fix_files: &[String], prior: &[PriorTouch]) -> Vec<Causa
             }
         })
         .collect();
+    out.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.file.cmp(&b.file))
+    });
+    out
+}
+
+/// Pick the dominant culprit from a per-line list of blame commit shas: the sha
+/// that blames the most lines. Returns `(sha, attributed_lines, total_lines)`.
+/// Ties break to the lexically-smallest sha for determinism. None if empty.
+fn dominant_culprit(shas: &[String]) -> Option<(String, usize, usize)> {
+    use std::collections::HashMap;
+    if shas.is_empty() {
+        return None;
+    }
+    let total = shas.len();
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for s in shas {
+        *counts.entry(s.as_str()).or_default() += 1;
+    }
+    // Max by count, then smallest sha. Iterate sorted for deterministic tie-break.
+    let mut pairs: Vec<(&str, usize)> = counts.into_iter().collect();
+    pairs.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    let (sha, n) = pairs[0];
+    Some((sha.to_string(), n, total))
+}
+
+/// Confidence for a blame-derived culprit. Blame is a precise signal, so it is
+/// floored at 0.6 (above the recency+overlap heuristic's typical range) and
+/// scales toward 0.98 as the culprit's share of the blamed lines approaches 1.0.
+fn blame_confidence(attributed: usize, total: usize) -> f64 {
+    let frac = attributed as f64 / (total.max(1) as f64);
+    (0.6 + 0.38 * frac).clamp(0.6, 0.98)
+}
+
+/// Merge the recency+overlap `fallback` candidates with git-blame results
+/// (per-file lists of culprit shas). Where blame produced a dominant culprit for
+/// a file, it replaces that file's fallback candidate (sharper, exact commit);
+/// files with no blame keep their fallback; files seen only by blame are added.
+/// Deterministic order: confidence desc, then file asc.
+fn merge_causality(
+    fallback: Vec<CausalityCandidate>,
+    blame_map: &std::collections::HashMap<String, Vec<String>>,
+) -> Vec<CausalityCandidate> {
+    use std::collections::HashMap;
+    let mut by_file: HashMap<String, CausalityCandidate> =
+        fallback.into_iter().map(|c| (c.file.clone(), c)).collect();
+
+    for (file, shas) in blame_map {
+        if let Some((sha, attributed, total)) = dominant_culprit(shas) {
+            by_file.insert(
+                file.clone(),
+                CausalityCandidate {
+                    file: file.clone(),
+                    culprit_sha: sha,
+                    culprit_bead_id: String::new(), // unknown from blame alone
+                    confidence: blame_confidence(attributed, total),
+                },
+            );
+        }
+    }
+
+    let mut out: Vec<CausalityCandidate> = by_file.into_values().collect();
     out.sort_by(|a, b| {
         b.confidence
             .partial_cmp(&a.confidence)
@@ -890,6 +989,77 @@ mod tests {
             },
         ];
         assert!(reconstruct_culprits(&fix_files, &prior).is_empty());
+    }
+
+    fn cand(file: &str, sha: &str, bead: &str, conf: f64) -> CausalityCandidate {
+        CausalityCandidate {
+            file: file.to_string(),
+            culprit_sha: sha.to_string(),
+            culprit_bead_id: bead.to_string(),
+            confidence: conf,
+        }
+    }
+
+    #[test]
+    fn test_dominant_culprit_majority_and_ties() {
+        let shas = vec![
+            "aaa".to_string(),
+            "bbb".to_string(),
+            "aaa".to_string(),
+            "aaa".to_string(),
+        ];
+        assert_eq!(dominant_culprit(&shas), Some(("aaa".to_string(), 3, 4)));
+        // Tie on count → lexically smallest sha wins (deterministic).
+        let tie = vec!["zzz".to_string(), "mmm".to_string()];
+        assert_eq!(dominant_culprit(&tie), Some(("mmm".to_string(), 1, 2)));
+        assert_eq!(dominant_culprit(&[]), None);
+    }
+
+    #[test]
+    fn test_blame_confidence_band() {
+        // Unanimous blame → top of band; split blame → lower but floored at 0.6.
+        assert!((blame_confidence(10, 10) - 0.98).abs() < 1e-9);
+        assert!(blame_confidence(1, 10) >= 0.6);
+        assert!(blame_confidence(5, 10) > blame_confidence(1, 10));
+    }
+
+    #[test]
+    fn test_merge_causality_blame_overrides_fallback() {
+        use std::collections::HashMap;
+        // Fallback put sha_old on a.rs at 0.95; blame says the real culprit is
+        // sha_real (unanimous), so blame replaces it with a blame-band score.
+        let fallback = vec![
+            cand("src/a.rs", "sha_old", "bo-old", 0.95),
+            cand("src/b.rs", "sha_b", "bo-b", 0.4),
+        ];
+        let mut blame: HashMap<String, Vec<String>> = HashMap::new();
+        blame.insert(
+            "src/a.rs".to_string(),
+            vec!["sha_real".to_string(), "sha_real".to_string()],
+        );
+        let merged = merge_causality(fallback, &blame);
+
+        let a = merged.iter().find(|c| c.file == "src/a.rs").unwrap();
+        assert_eq!(a.culprit_sha, "sha_real");
+        assert_eq!(a.culprit_bead_id, ""); // blame doesn't know the bead
+        assert!((a.confidence - 0.98).abs() < 1e-9);
+
+        // b.rs had no blame → fallback survives untouched.
+        let b = merged.iter().find(|c| c.file == "src/b.rs").unwrap();
+        assert_eq!(b.culprit_sha, "sha_b");
+        assert_eq!(b.culprit_bead_id, "bo-b");
+    }
+
+    #[test]
+    fn test_merge_causality_adds_blame_only_files() {
+        use std::collections::HashMap;
+        // A file blame found but with no fallback candidate is still recorded.
+        let mut blame: HashMap<String, Vec<String>> = HashMap::new();
+        blame.insert("src/new.rs".to_string(), vec!["sha_intro".to_string()]);
+        let merged = merge_causality(vec![], &blame);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].file, "src/new.rs");
+        assert_eq!(merged[0].culprit_sha, "sha_intro");
     }
 }
 

--- a/src/index/git.rs
+++ b/src/index/git.rs
@@ -512,6 +512,92 @@ impl GitAnalyzer {
         let stdout = String::from_utf8_lossy(&output.stdout);
         Ok(parse_blame_porcelain(&stdout))
     }
+
+    /// Blame a line range as of a specific revision (instead of the working tree).
+    /// Used by SZZ-style culprit detection: blame the pre-fix file (`<fix>^`) at
+    /// the lines a fix removed to find the commit that introduced them.
+    pub fn blame_lines_at_rev(
+        &self,
+        rev: &str,
+        file_path: &str,
+        start: u32,
+        end: u32,
+    ) -> Result<Vec<BlameEntry>> {
+        let range = format!("{},{}", start, end);
+        let output = Command::new("git")
+            .args(["blame", rev, "-L", &range, "--porcelain", "--", file_path])
+            .current_dir(&self.repo_root)
+            .output()
+            .context("Failed to run git blame")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "git blame {} failed for {}:{}-{}: {}",
+                rev,
+                file_path,
+                start,
+                end,
+                stderr.trim()
+            );
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(parse_blame_porcelain(&stdout))
+    }
+
+    /// SZZ-lite culprit detection: find the commits that last touched the lines a
+    /// fix commit removed or modified in `file`.
+    ///
+    /// Diffs `fix_sha` against its first parent (zero context) to get the
+    /// old-side line ranges the fix deleted, then blames those ranges against
+    /// `fix_sha^`. Returns one [`BlameEntry`] per blamed line (the introducing
+    /// commit + its old line number). Returns an empty vec when the fix only
+    /// *added* lines, when `file` is newly created by the fix, or when blame is
+    /// unavailable (e.g. the fix is a root commit with no parent).
+    pub fn blame_fix_culprits(&self, fix_sha: &str, file: &str) -> Result<Vec<BlameEntry>> {
+        // Diff the fix against its first parent, no context, for this file only.
+        let output = Command::new("git")
+            .args([
+                "show",
+                fix_sha,
+                "--unified=0",
+                "--pretty=format:",
+                "--",
+                file,
+            ])
+            .current_dir(&self.repo_root)
+            .output()
+            .context("Failed to run git show")?;
+
+        if !output.status.success() {
+            anyhow::bail!(
+                "git show failed for {} {}: {}",
+                fix_sha,
+                file,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        let diff = String::from_utf8_lossy(&output.stdout);
+        let parsed = parse_unified_diff(&diff);
+        // removed_lines are old-side line numbers in the pre-fix file.
+        let removed = match parsed.get(file) {
+            Some((_added, removed)) if !removed.is_empty() => removed.clone(),
+            _ => return Ok(Vec::new()),
+        };
+
+        let parent = format!("{fix_sha}^");
+        let mut entries = Vec::new();
+        for (start, end) in group_consecutive(&removed) {
+            // A missing parent (root commit) or a file absent at the parent blames
+            // to nothing — skip those ranges rather than failing the whole bug.
+            if let Ok(mut e) = self.blame_lines_at_rev(&parent, file, start, end) {
+                entries.append(&mut e);
+            }
+        }
+        Ok(entries)
+    }
 }
 
 /// Parse file history log into entries
@@ -859,6 +945,33 @@ fn parse_hunk_header(line: &str, added_lines: &mut Vec<u32>, removed_lines: &mut
     }
 }
 
+/// Collapse a set of line numbers into contiguous `(start, end)` inclusive
+/// ranges. Input is sorted and de-duplicated first, so callers may pass the
+/// removed-line lists from multiple hunks in any order. Empty input → no ranges.
+fn group_consecutive(lines: &[u32]) -> Vec<(u32, u32)> {
+    let mut sorted: Vec<u32> = lines.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+
+    let mut ranges = Vec::new();
+    let mut iter = sorted.into_iter();
+    let Some(first) = iter.next() else {
+        return ranges;
+    };
+    let (mut start, mut end) = (first, first);
+    for n in iter {
+        if n == end + 1 {
+            end = n;
+        } else {
+            ranges.push((start, end));
+            start = n;
+            end = n;
+        }
+    }
+    ranges.push((start, end));
+    ranges
+}
+
 /// Parse a range spec like "42" (1 line at 42) or "42,5" (5 lines starting at 42).
 /// A count of 0 means no lines (pure addition or deletion on the other side).
 fn parse_range_spec(spec: &str) -> (u32, u32) {
@@ -931,6 +1044,21 @@ fn parse_blame_porcelain(output: &str) -> Vec<BlameEntry> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_group_consecutive() {
+        // Unsorted + duplicate input collapses into contiguous inclusive ranges.
+        assert_eq!(
+            group_consecutive(&[5, 1, 2, 3, 7, 6, 3]),
+            vec![(1, 3), (5, 7)]
+        );
+        // Single isolated lines each form their own range.
+        assert_eq!(group_consecutive(&[10, 20, 30]), vec![(10, 10), (20, 20), (30, 30)]);
+        // One run.
+        assert_eq!(group_consecutive(&[4, 5, 6]), vec![(4, 6)]);
+        // Empty input → no ranges.
+        assert_eq!(group_consecutive(&[]), Vec::<(u32, u32)>::new());
+    }
 
     #[test]
     fn test_parse_git_log() {
@@ -1148,6 +1276,75 @@ mod tests {
         // A very restrictive since should return empty or same
         let churn_future = analyzer.get_file_churn(Some("2099-01-01")).unwrap();
         assert!(churn_future.is_empty());
+    }
+
+    #[test]
+    fn test_blame_fix_culprits_finds_introducing_commit() {
+        // SZZ-lite: a "culprit" commit introduces a buggy line; a later "fix"
+        // commit changes that line. blame_fix_culprits should attribute the
+        // removed line to the culprit commit, not the fix.
+        let dir = setup_test_repo();
+        let path = dir.path();
+        let run = |args: &[&str]| {
+            Command::new("git").args(args).current_dir(path).output().unwrap()
+        };
+
+        // c0: baseline file.
+        std::fs::write(path.join("auth.rs"), "fn ok() {}\nlet x = 1;\nfn end() {}\n").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "baseline"]);
+
+        // culprit: introduce the buggy middle line.
+        std::fs::write(path.join("auth.rs"), "fn ok() {}\nlet x = BUGGY;\nfn end() {}\n").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "introduce bug"]);
+        let culprit_sha = String::from_utf8_lossy(&run(&["rev-parse", "HEAD"]).stdout)
+            .trim()
+            .to_string();
+
+        // fix: change the buggy line (removes the culprit's version).
+        std::fs::write(path.join("auth.rs"), "fn ok() {}\nlet x = 2;\nfn end() {}\n").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "fix bug"]);
+        let fix_sha = String::from_utf8_lossy(&run(&["rev-parse", "HEAD"]).stdout)
+            .trim()
+            .to_string();
+
+        let analyzer = GitAnalyzer::new(path).unwrap();
+        let entries = analyzer.blame_fix_culprits(&fix_sha, "auth.rs").unwrap();
+
+        // The removed line was last touched by the culprit commit.
+        assert!(!entries.is_empty(), "expected blame to attribute removed lines");
+        assert!(
+            entries.iter().all(|e| e.commit_hash == culprit_sha),
+            "all blamed lines should point at the culprit, got {:?}",
+            entries
+        );
+    }
+
+    #[test]
+    fn test_blame_fix_culprits_pure_addition_is_empty() {
+        // A fix that only *adds* lines has no removed lines to blame → empty.
+        let dir = setup_test_repo();
+        let path = dir.path();
+        let run = |args: &[&str]| {
+            Command::new("git").args(args).current_dir(path).output().unwrap()
+        };
+
+        std::fs::write(path.join("a.rs"), "one\n").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "c0"]);
+
+        std::fs::write(path.join("a.rs"), "one\ntwo\n").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "append only"]);
+        let fix_sha = String::from_utf8_lossy(&run(&["rev-parse", "HEAD"]).stdout)
+            .trim()
+            .to_string();
+
+        let analyzer = GitAnalyzer::new(path).unwrap();
+        let entries = analyzer.blame_fix_culprits(&fix_sha, "a.rs").unwrap();
+        assert!(entries.is_empty(), "pure addition should yield no culprits");
     }
 
     #[test]


### PR DESCRIPTION
## What

Follow-up to bo-s1kb. v1 inferred a bug's culprit commit by recency+overlap (the most-recent prior commit touching the fix's files). This adds **SZZ-lite git-blame sharpening**: blame the exact lines a fix *removed* against the fix's parent to pin the precise introducing commit, at higher confidence — falling back to recency+overlap where blame can't help.

Updates `bug_causality.culprit_sha` + `.confidence`.

## How

**`src/index/git.rs`**
- `blame_lines_at_rev(rev, file, start, end)` — blame a range as of a revision (not the worktree).
- `blame_fix_culprits(fix_sha, file)` — `git show --unified=0` → reuse `parse_unified_diff` for the removed (old-side) line ranges → `group_consecutive` → blame each range at `<fix_sha>^`. Returns one `BlameEntry` per blamed line. Empty for pure-addition fixes, files newly created by the fix, or root commits (no parent).
- `group_consecutive(lines)` range helper.

**`src/cli/bead.rs`** (`reconstruct-causality`)
- For each fix commit + touched file, accumulate blame culprit shas.
- `merge_causality(fallback, blame_map)`: per file, blame's **dominant culprit** replaces the recency+overlap candidate where available; files without blame keep the fallback; blame-only files are added.
- `dominant_culprit` (deterministic tie-break) + `blame_confidence` (floored 0.6, scales to 0.98 with blame concentration — above the overlap heuristic's 0.95 cap).
- Blame culprits store the sha only (`culprit_bead_id` → None). Degrades gracefully when not a git repo.

## Tests

- Pure units: `dominant_culprit` (majority + ties), `blame_confidence` band, `merge_causality` (blame overrides fallback; blame-only files added), `group_consecutive`.
- **Integration on a known bug** (temp git repo): a commit introduces a buggy line, a later fix changes it → `blame_fix_culprits` attributes the removed line to the *introducing* commit, not the fix. Plus a pure-addition → empty case.

`cargo test --bin bobbin` green for the touched modules; build + clippy clean.

## AC

✅ blame-based causality where available ✅ falls back to recency+overlap ✅ tested on a known bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)