### PR TITLE
chore: bump version 0.4.0 -> 0.5.0 for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bobbin"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Bobbin Team"]
 description = "Local-first context injection engine for AI coding agents"


### PR DESCRIPTION
Bump bobbin to **0.5.0** so ops can verify the deploy by version, not just sha. Many new features have landed since 0.4.0 (cross-repo + per-repo coupling, test↔source coverage, bug causality via git-blame, bead indexing, configurable chunking, MCP tool additions).

Tag **v0.5.0** should be cut on the post-merge bump commit (the commit whose `Cargo.toml` reads 0.5.0), not the pre-bump HEAD.

Trivial version-only change. Requested by dearing for a Stiwi-priority deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)