### PR TITLE
docs(plans): status-label the 4 eval plans — all implemented/record (go2i sweep)

### DIFF
--- a/docs/plans/adaptive-defaults.md
+++ b/docs/plans/adaptive-defaults.md
@@ -1,5 +1,7 @@
 # Design: Adaptive Defaults — Project-Aware Search Configuration
 
+> **Implementation status (2026-07-23, franklin):** ✅ **Implemented** — corroborates the doc's own COMPLETE self-claim by mechanism: shipped as the `bobbin calibrate` command (`src/cli/calibrate.rs` — `CalibrateArgs`, writes best config to `.bobbin/calibration.json`), wired as a CLI subcommand (`src/cli/mod.rs:84` `Calibrate(...)`), and auto-runs at the end of `bobbin index` (skippable via `--skip-calibrate`). Verified 2026-07-23.
+
 **Status**: COMPLETE — All 4 phases shipped (2026-02-26)
 
 ## Problem

--- a/docs/plans/calibration-sweep-results.md
+++ b/docs/plans/calibration-sweep-results.md
@@ -1,5 +1,7 @@
 # Calibration Sweep Results
 
+> **Implementation status (2026-07-23, franklin):** ✅ **Record (findings applied)** — this is a results/record doc, not a plan. Its single biggest finding — filtering commit chunks from context injection — is landed (`a975e76` "fix: filter ChunkType::Commit out of context injection"). The sweeps are reproducible via `bobbin calibrate` (src/cli/calibrate.rs). Verified 2026-07-23.
+
 ## Round 2: Post Commit-Chunk Filter (2026-02-26)
 
 180-config grid (5 sw × 3 dd × 1 k × 3 b × 4 sl), 20 samples per repo.

--- a/docs/plans/eval-framework.md
+++ b/docs/plans/eval-framework.md
@@ -1,5 +1,7 @@
 # Bobbin Eval Framework
 
+> **Implementation status (2026-07-23, franklin):** ✅ **Implemented** — the framework exists as designed: `eval/runner/{cli,workspace,bobbin_setup,agent_runner,task_loader}.py`, `eval/scorer/{aggregator,diff_scorer,llm_judge,test_scorer,injection_scorer}.py`, 40 task YAMLs under `eval/tasks/*.yaml` (cargo/django/go/nushell/pandas/polars/ruff/typst), and the pairwise LLM judge `eval/prompts/pairwise_judge.md.j2` + `eval/scorer/llm_judge.py`. Verified by directory listing 2026-07-23. Additional study runners (`run-baseline-study.sh`, `run-ablation-study.sh`, `analyze-baselines.py`) wrap this core.
+
 ## Context
 
 Bobbin injects relevant code context into Claude Code via hooks, but we have no empirical proof it helps. We need a reproducible evaluation framework that compares Claude Code **with** and **without** bobbin on real coding tasks, using real human commits as ground truth. This serves two purposes: (1) guide iterative improvement of bobbin, and (2) produce compelling results to attract users.

--- a/docs/plans/eval-metrics-gate-tuning.md
+++ b/docs/plans/eval-metrics-gate-tuning.md
@@ -1,5 +1,7 @@
 # Eval Framework Improvements: Metrics, Gate Tuning & Agent Guidance
 
+> **Implementation status (2026-07-23, franklin):** ✅ **Implemented** — the core changes landed: gate threshold default 0.75→0.45 (`src/config.rs:556` `gate_threshold: 0.45`, test-asserted at :1358); token/cost capture in the report (`eval/analysis/report.py` reads `token_usage.total_cost_usd`/`input_tokens`); and the workspace CLAUDE.md instructing bobbin CLI usage (`eval/workspace-claude-md.md`). Verified by grep 2026-07-23. Targets the eval framework, which is fully built (see eval-framework.md).
+
 ## Context
 
 Flask eval reruns showed bobbin **never injected context** (gate_skip on all 5 tasks, 0 injections, 0 manual bobbin commands). The agent gets the prime context but never uses bobbin CLI tools. We're also missing token usage, gate score details, and tool use traces — data needed to understand gaps and tune the system.


### PR DESCRIPTION
Plan-implementation sweep: assess + label the 4 eval-track plan docs against the code (verify by mechanism).

All four are already shipped; they just lacked status labels. Added a status block to each with inline evidence:

- **eval-framework.md** ✅ Implemented — `eval/runner/*` + `eval/scorer/*` + 40 task YAMLs + pairwise LLM judge (`prompts/pairwise_judge.md.j2`) all present as designed.
- **eval-metrics-gate-tuning.md** ✅ Implemented — gate default 0.45 (`config.rs:556`, test-asserted), token/cost capture in `eval/analysis/report.py`, workspace CLAUDE.md present.
- **adaptive-defaults.md** ✅ Implemented — the `bobbin calibrate` command (`cli/calibrate.rs`, wired in `cli/mod.rs`, auto-runs after index); corroborates the doc's COMPLETE self-claim by mechanism.
- **calibration-sweep-results.md** ✅ Record — findings applied; commit-chunk filter landed (`a975e76`); reproducible via `bobbin calibrate`.

No implementation gaps in these four — docs-only change (status blocks). Part of the plan-labeling sweep.